### PR TITLE
add setuptools-scm to get version from vcs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "keycloak-basic-auth-proxy"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Proxy server for basic authentication based on Keycloak access tokens"
 readme = "README.md"
-repository = "https://github.com/khj809/keycloak-basic-auth-proxy"
-authors = ["Haejoon Kim <onsealeatang@gmail.com>"]
-license = "MIT"
+authors = [
+    {name = "Haejoon Kim", email = "onsealeatang@gmail.com"},
+]
+license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -14,10 +15,20 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = []
 
+[project.urls]
+Repository = "https://github.com/khj809/keycloak-basic-auth-proxy"
+
 [dependency-groups]
 dev = [
     "ruff>=0.9.7",
 ]
+
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# can be empty if no extra settings are needed, presence enables setuptools-scm
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
- Use setuptools and setuptools-scm to get dynamic version from Git tag
- Fix `pyproject.toml` to comply with modern PEP guidelines